### PR TITLE
[feat/#31] 도서 상세 페이지 구현

### DIFF
--- a/app/src/main/java/sopt/org/millie/core/designsystem/theme/Color.kt
+++ b/app/src/main/java/sopt/org/millie/core/designsystem/theme/Color.kt
@@ -28,6 +28,7 @@ val Black = Color(0xFF000000)
 
 // Background Colors
 val Background = Color(0xFFFEFEFE)
+val BookDetailBackground = Color(0xFFE0E3ED)
 
 @Immutable
 data class MillieColors(
@@ -50,6 +51,7 @@ data class MillieColors(
     val darkGray2: Color = DarkGray2,
     val black: Color = Black,
     val background: Color = Background,
+    val bookDetailBackground: Color = BookDetailBackground,
 )
 
 val defaultMillieColors = MillieColors(
@@ -72,6 +74,7 @@ val defaultMillieColors = MillieColors(
     darkGray2 = DarkGray2,
     black = Black,
     background = Background,
+    bookDetailBackground = BookDetailBackground,
 )
 
 val localMillieColorsProvider = staticCompositionLocalOf { defaultMillieColors }

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailScreen.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailScreen.kt
@@ -1,0 +1,219 @@
+package sopt.org.millie.presentation.bookdetail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import sopt.org.millie.core.designsystem.theme.MillieTheme
+import sopt.org.millie.core.util.customShadow
+import sopt.org.millie.presentation.bookdetail.component.bar.BookDetailTopbar
+import sopt.org.millie.presentation.bookdetail.component.bar.ReadNowBar
+import sopt.org.millie.presentation.bookdetail.component.book.BookDataSection
+import sopt.org.millie.presentation.bookdetail.component.book.BookInfoSection
+import sopt.org.millie.presentation.bookdetail.component.book.BookInfoSubtitle
+import sopt.org.millie.presentation.bookdetail.component.book.BookIntroduceSection
+import sopt.org.millie.presentation.bookdetail.component.book.BookReviewSection
+import sopt.org.millie.presentation.bookdetail.component.book.BookSimilarSection
+
+@Composable
+fun BookDetailRoute(
+    viewModel: BookDetailViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    BookDetailScreen(
+        uiState = uiState,
+        onBackButtonClick = viewModel::onBackButtonClicked,
+        onCompletedRateClick = viewModel::onCompletedRateClicked,
+        onAgeGenderClick = viewModel::onAgeGenderClicked,
+        onImageClick = viewModel::onImageClicked
+    )
+}
+
+@Composable
+private fun BookDetailScreen(
+    uiState: BookDetailState,
+    onBackButtonClick: () -> Unit,
+    onCompletedRateClick: () -> Unit,
+    onAgeGenderClick: () -> Unit,
+    onImageClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize(),
+    ) {
+        BookDetailContent(
+            uiState = uiState,
+            onBackButtonClick = onBackButtonClick,
+            onCompletedRateClick = onCompletedRateClick,
+            onAgeGenderClick = onAgeGenderClick,
+            onImageClick = onImageClick,
+        )
+
+        ReadNowBar(
+            onButtonClick = {},
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun BookDetailContent(
+    uiState: BookDetailState,
+    onBackButtonClick: () -> Unit,
+    onCompletedRateClick: () -> Unit,
+    onAgeGenderClick: () -> Unit,
+    onImageClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = MillieTheme.colors.bookDetailBackground)
+            .verticalScroll(state = rememberScrollState()),
+    ) {
+        Spacer(modifier = Modifier.height(22.dp))
+
+        BookDetailTopbar(
+            bookDetailTopbarBackgroundColor = MillieTheme.colors.bookDetailBackground,
+            onBackButtonClick = onBackButtonClick,
+        )
+
+        AsyncImage(
+            model = uiState.bookDetailUiModel.bookCoverImageUrl,
+            contentDescription = null,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 84.dp, vertical = 46.dp)
+                .clip(shape = RoundedCornerShape(8.dp))
+                .customShadow(
+                    shape = RoundedCornerShape(8.dp),
+                    color = MillieTheme.colors.black.copy(
+                        alpha = 0.1f
+                    ),
+                    offsetX = 4.dp,
+                    offsetY = 8.dp
+                )
+                .customShadow(
+                    shape = RoundedCornerShape(8.dp),
+                    color = MillieTheme.colors.black.copy(
+                        alpha = 0.2f
+                    ),
+                    offsetX = 12.dp,
+                    offsetY = 8.dp
+                ),
+            contentScale = ContentScale.Crop,
+
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
+                .customShadow(
+                    shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+                    color = MillieTheme.colors.black.copy(
+                        alpha = 0.1f
+                    ),
+                    offsetY = (-5).dp
+                )
+                .background(color = MillieTheme.colors.white)
+                .padding(top = 40.dp)
+        ) {
+            BookInfoSection(
+                bookTitle = uiState.bookDetailUiModel.bookTitle,
+                bookAuthor = uiState.bookDetailUiModel.bookAuthor,
+                bookType = uiState.bookDetailUiModel.bookType,
+                publishDate = uiState.bookDetailUiModel.publishedDate,
+                totalReviewCount = uiState.bookDetailUiModel.totalReviewCount,
+                bookRate = uiState.bookDetailUiModel.bookRate,
+                completionRate = uiState.bookDetailUiModel.completionRate,
+            )
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            Line()
+
+            BookInfoSubtitle()
+
+            Line()
+
+            BookIntroduceSection(
+                bookDescription = uiState.bookDetailUiModel.bookDescription,
+                modifier = Modifier.padding(top = 50.dp, bottom = 30.dp)
+            )
+
+            Line()
+
+            BookReviewSection(
+                totalReviewCount = uiState.bookDetailUiModel.totalReviewCount,
+                bookReviews = uiState.bookDetailUiModel.reviews,
+                onReviewLikeClick = {},
+            )
+
+            Line()
+
+            BookDataSection(
+                onCompletedRateClick = onCompletedRateClick,
+                onAgeGenderClick = onAgeGenderClick,
+                isCompletedGraphChanged = uiState.isCompletedGraphChanged,
+                selectedType = uiState.selectedType,
+                onImageClick = onImageClick,
+                modifier = Modifier.padding(vertical = 30.dp)
+            )
+
+            Line()
+
+            BookSimilarSection(
+                books = uiState.similarBooks,
+                modifier = Modifier.padding(top = 30.dp, bottom = 20.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun Line(
+    modifier: Modifier = Modifier
+){
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(3.dp)
+            .background(color = MillieTheme.colors.lightGray1)
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun Preview() {
+    MillieTheme {
+        BookDetailScreen(
+            uiState = BookDetailState(),
+            onBackButtonClick = {},
+            onCompletedRateClick = {},
+            onAgeGenderClick = {},
+            onImageClick = {}
+        )
+    }
+
+}

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailScreen.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailScreen.kt
@@ -43,7 +43,7 @@ fun BookDetailRoute(
         onBackButtonClick = viewModel::onBackButtonClicked,
         onCompletedRateClick = viewModel::onCompletedRateClicked,
         onAgeGenderClick = viewModel::onAgeGenderClicked,
-        onImageClick = viewModel::onImageClicked
+        onImageClick = viewModel::onImageClicked,
     )
 }
 
@@ -84,7 +84,6 @@ private fun BookDetailContent(
     onImageClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -108,21 +107,20 @@ private fun BookDetailContent(
                 .customShadow(
                     shape = RoundedCornerShape(8.dp),
                     color = MillieTheme.colors.black.copy(
-                        alpha = 0.1f
+                        alpha = 0.1f,
                     ),
                     offsetX = 4.dp,
-                    offsetY = 8.dp
+                    offsetY = 8.dp,
                 )
                 .customShadow(
                     shape = RoundedCornerShape(8.dp),
                     color = MillieTheme.colors.black.copy(
-                        alpha = 0.2f
+                        alpha = 0.2f,
                     ),
                     offsetX = 12.dp,
-                    offsetY = 8.dp
+                    offsetY = 8.dp,
                 ),
             contentScale = ContentScale.Crop,
-
         )
 
         Column(
@@ -132,12 +130,12 @@ private fun BookDetailContent(
                 .customShadow(
                     shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
                     color = MillieTheme.colors.black.copy(
-                        alpha = 0.1f
+                        alpha = 0.1f,
                     ),
-                    offsetY = (-5).dp
+                    offsetY = (-5).dp,
                 )
                 .background(color = MillieTheme.colors.white)
-                .padding(top = 40.dp)
+                .padding(top = 40.dp),
         ) {
             BookInfoSection(
                 bookTitle = uiState.bookDetailUiModel.bookTitle,
@@ -159,7 +157,7 @@ private fun BookDetailContent(
 
             BookIntroduceSection(
                 bookDescription = uiState.bookDetailUiModel.bookDescription,
-                modifier = Modifier.padding(top = 50.dp, bottom = 30.dp)
+                modifier = Modifier.padding(top = 50.dp, bottom = 30.dp),
             )
 
             Line()
@@ -178,14 +176,14 @@ private fun BookDetailContent(
                 isCompletedGraphChanged = uiState.isCompletedGraphChanged,
                 selectedType = uiState.selectedType,
                 onImageClick = onImageClick,
-                modifier = Modifier.padding(vertical = 30.dp)
+                modifier = Modifier.padding(vertical = 30.dp),
             )
 
             Line()
 
             BookSimilarSection(
                 books = uiState.similarBooks,
-                modifier = Modifier.padding(top = 30.dp, bottom = 20.dp)
+                modifier = Modifier.padding(top = 30.dp, bottom = 20.dp),
             )
         }
     }
@@ -193,13 +191,13 @@ private fun BookDetailContent(
 
 @Composable
 private fun Line(
-    modifier: Modifier = Modifier
-){
+    modifier: Modifier = Modifier,
+) {
     Box(
         modifier = modifier
             .fillMaxWidth()
             .height(3.dp)
-            .background(color = MillieTheme.colors.lightGray1)
+            .background(color = MillieTheme.colors.lightGray1),
     )
 }
 
@@ -212,8 +210,7 @@ private fun Preview() {
             onBackButtonClick = {},
             onCompletedRateClick = {},
             onAgeGenderClick = {},
-            onImageClick = {}
+            onImageClick = {},
         )
     }
-
 }

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailScreen.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -56,22 +57,26 @@ private fun BookDetailScreen(
     onImageClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxSize(),
-    ) {
-        BookDetailContent(
-            uiState = uiState,
-            onBackButtonClick = onBackButtonClick,
-            onCompletedRateClick = onCompletedRateClick,
-            onAgeGenderClick = onAgeGenderClick,
-            onImageClick = onImageClick,
-        )
-
-        ReadNowBar(
-            onButtonClick = {},
-            modifier = Modifier.weight(1f),
-        )
+    Scaffold(
+        bottomBar = {
+            ReadNowBar(
+                onButtonClick = {},
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            BookDetailContent(
+                uiState = uiState,
+                onBackButtonClick = onBackButtonClick,
+                onCompletedRateClick = onCompletedRateClick,
+                onAgeGenderClick = onAgeGenderClick,
+                onImageClick = onImageClick,
+            )
+        }
     }
 }
 
@@ -134,7 +139,7 @@ private fun BookDetailContent(
                     ),
                     offsetY = (-5).dp,
                 )
-                .background(color = MillieTheme.colors.white)
+                .background(color = MillieTheme.colors.background)
                 .padding(top = 40.dp),
         ) {
             BookInfoSection(

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailScreen.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailScreen.kt
@@ -1,7 +1,6 @@
 package sopt.org.millie.presentation.bookdetail
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -45,16 +45,18 @@ fun BookDetailRoute(
         onCompletedRateClick = viewModel::onCompletedRateClicked,
         onAgeGenderClick = viewModel::onAgeGenderClicked,
         onImageClick = viewModel::onImageClicked,
+        onReviewLikeClick = viewModel::onReviewLikeClicked,
     )
 }
 
 @Composable
 private fun BookDetailScreen(
-    uiState: BookDetailState,
+    uiState: BookDetailUiState,
     onBackButtonClick: () -> Unit,
     onCompletedRateClick: () -> Unit,
     onAgeGenderClick: () -> Unit,
     onImageClick: () -> Unit,
+    onReviewLikeClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -75,6 +77,7 @@ private fun BookDetailScreen(
                 onCompletedRateClick = onCompletedRateClick,
                 onAgeGenderClick = onAgeGenderClick,
                 onImageClick = onImageClick,
+                onReviewLikeClick = onReviewLikeClick,
             )
         }
     }
@@ -82,11 +85,12 @@ private fun BookDetailScreen(
 
 @Composable
 private fun BookDetailContent(
-    uiState: BookDetailState,
+    uiState: BookDetailUiState,
     onBackButtonClick: () -> Unit,
     onCompletedRateClick: () -> Unit,
     onAgeGenderClick: () -> Unit,
     onImageClick: () -> Unit,
+    onReviewLikeClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -116,6 +120,7 @@ private fun BookDetailContent(
                     ),
                     offsetX = 4.dp,
                     offsetY = 8.dp,
+                    blur = 8.dp,
                 )
                 .customShadow(
                     shape = RoundedCornerShape(8.dp),
@@ -124,6 +129,7 @@ private fun BookDetailContent(
                     ),
                     offsetX = 12.dp,
                     offsetY = 8.dp,
+                    blur = 24.dp,
                 ),
             contentScale = ContentScale.Crop,
         )
@@ -142,15 +148,17 @@ private fun BookDetailContent(
                 .background(color = MillieTheme.colors.background)
                 .padding(top = 40.dp),
         ) {
-            BookInfoSection(
-                bookTitle = uiState.bookDetailUiModel.bookTitle,
-                bookAuthor = uiState.bookDetailUiModel.bookAuthor,
-                bookType = uiState.bookDetailUiModel.bookType,
-                publishDate = uiState.bookDetailUiModel.publishedDate,
-                totalReviewCount = uiState.bookDetailUiModel.totalReviewCount,
-                bookRate = uiState.bookDetailUiModel.bookRate,
-                completionRate = uiState.bookDetailUiModel.completionRate,
-            )
+            with(uiState.bookDetailUiModel) {
+                BookInfoSection(
+                    bookTitle = bookTitle,
+                    bookAuthor = bookAuthor,
+                    bookType = bookType,
+                    publishDate = publishedDate,
+                    totalReviewCount = totalReviewCount,
+                    bookRate = bookRate,
+                    completionRate = completionRate,
+                )
+            }
 
             Spacer(modifier = Modifier.height(10.dp))
 
@@ -170,7 +178,8 @@ private fun BookDetailContent(
             BookReviewSection(
                 totalReviewCount = uiState.bookDetailUiModel.totalReviewCount,
                 bookReviews = uiState.bookDetailUiModel.reviews,
-                onReviewLikeClick = {},
+                onReviewLikeClick = onReviewLikeClick,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 30.dp),
             )
 
             Line()
@@ -198,11 +207,9 @@ private fun BookDetailContent(
 private fun Line(
     modifier: Modifier = Modifier,
 ) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(3.dp)
-            .background(color = MillieTheme.colors.lightGray1),
+    HorizontalDivider(
+        thickness = 3.dp,
+        color = MillieTheme.colors.lightGray1,
     )
 }
 
@@ -211,11 +218,12 @@ private fun Line(
 private fun Preview() {
     MillieTheme {
         BookDetailScreen(
-            uiState = BookDetailState(),
+            uiState = BookDetailUiState(),
             onBackButtonClick = {},
             onCompletedRateClick = {},
             onAgeGenderClick = {},
             onImageClick = {},
+            onReviewLikeClick = {},
         )
     }
 }

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailState.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailState.kt
@@ -1,0 +1,14 @@
+package sopt.org.millie.presentation.bookdetail
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import sopt.org.millie.presentation.bookdetail.model.BookDataType
+import sopt.org.millie.presentation.bookdetail.model.BookDetailModel
+import sopt.org.millie.presentation.bookdetail.model.BookSimilarModel
+
+data class BookDetailState(
+    val bookDetailUiModel: BookDetailModel = BookDetailModel(),
+    val isCompletedGraphChanged: Boolean = true,
+    val selectedType: BookDataType = BookDataType.COMPLETED_RATE,
+    val similarBooks: ImmutableList<BookSimilarModel> = persistentListOf()
+)

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailState.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailState.kt
@@ -10,5 +10,5 @@ data class BookDetailState(
     val bookDetailUiModel: BookDetailModel = BookDetailModel(),
     val isCompletedGraphChanged: Boolean = true,
     val selectedType: BookDataType = BookDataType.COMPLETED_RATE,
-    val similarBooks: ImmutableList<BookSimilarModel> = persistentListOf()
+    val similarBooks: ImmutableList<BookSimilarModel> = persistentListOf(),
 )

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailUiState.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailUiState.kt
@@ -1,13 +1,15 @@
 package sopt.org.millie.presentation.bookdetail
 
+import androidx.compose.runtime.Immutable
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import sopt.org.millie.presentation.bookdetail.model.BookDataType
 import sopt.org.millie.presentation.bookdetail.model.BookDetailModel
 import sopt.org.millie.presentation.bookdetail.model.BookSimilarModel
 
-data class BookDetailState(
-    val bookDetailUiModel: BookDetailModel = BookDetailModel(),
+@Immutable
+data class BookDetailUiState(
+    val bookDetailUiModel: BookDetailModel = BookDetailModel(bookId = 0, bookCoverImageUrl = "", bookTitle = "", bookAuthor = "", bookType = "", publishedDate = "", bookRate = 0f, totalReviewCount = 0, completionRate = 0, bookDescription = ""),
     val isCompletedGraphChanged: Boolean = true,
     val selectedType: BookDataType = BookDataType.COMPLETED_RATE,
     val similarBooks: ImmutableList<BookSimilarModel> = persistentListOf(),

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailViewModel.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailViewModel.kt
@@ -1,0 +1,86 @@
+package sopt.org.millie.presentation.bookdetail
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import sopt.org.millie.R
+import sopt.org.millie.presentation.bookdetail.model.BookDataType
+import sopt.org.millie.presentation.bookdetail.model.BookSimilarModel
+import javax.inject.Inject
+
+@HiltViewModel
+class BookDetailViewModel @Inject constructor() : ViewModel() {
+    private val _uiState = MutableStateFlow(BookDetailState())
+    val uiState: StateFlow<BookDetailState> = _uiState.asStateFlow()
+
+    init {
+        loadData()
+    }
+
+    private fun loadData() {
+        loadDummyData()
+        // TODO: 서버 연결
+    }
+
+    private fun loadDummyData() {
+        val dummySimilarBooks = persistentListOf(
+            BookSimilarModel(
+                bookImage = R.drawable.img_detail_book1,
+                bookTitle = "사탄탱고",
+                bookAuthor = "크러스너호르커이",
+            ),
+            BookSimilarModel(
+                bookImage = R.drawable.img_detail_book2,
+                bookTitle = "고래",
+                bookAuthor = "천명권",
+            ),
+            BookSimilarModel(
+                bookImage = R.drawable.img_detail_book3,
+                bookTitle = "삼체",
+                bookAuthor = "류츠신",
+            ),
+            BookSimilarModel(
+                bookImage = R.drawable.img_detail_book4,
+                bookTitle = "홍학의 자리",
+                bookAuthor = "정해연",
+            ),
+
+            )
+
+        _uiState.update {
+            it.copy(similarBooks = dummySimilarBooks)
+        }
+    }
+
+    fun onBackButtonClicked() {
+        //TODO: 네비 연결
+    }
+
+    fun onCompletedRateClicked() {
+        _uiState.update {
+            it.copy(
+                selectedType = BookDataType.COMPLETED_RATE,
+            )
+        }
+    }
+
+    fun onAgeGenderClicked() {
+        _uiState.update {
+            it.copy(
+                selectedType = BookDataType.AGE_GENDER,
+            )
+        }
+    }
+
+    fun onImageClicked() {
+        _uiState.update {
+            it.copy(
+                isCompletedGraphChanged = !it.isCompletedGraphChanged,
+            )
+        }
+    }
+}

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailViewModel.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailViewModel.kt
@@ -16,8 +16,8 @@ import javax.inject.Inject
 class BookDetailViewModel
     @Inject
     constructor() : ViewModel() {
-    private val _uiState = MutableStateFlow(BookDetailState())
-    val uiState: StateFlow<BookDetailState> = _uiState.asStateFlow()
+    private val _uiState = MutableStateFlow(BookDetailUiState())
+    val uiState: StateFlow<BookDetailUiState> = _uiState.asStateFlow()
 
     init {
         loadData()
@@ -83,5 +83,9 @@ class BookDetailViewModel
                 isCompletedGraphChanged = !it.isCompletedGraphChanged,
             )
         }
+    }
+
+    fun onReviewLikeClicked(reviewId: Long) {
+        // TODO: 서버 연결
     }
 }

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailViewModel.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/BookDetailViewModel.kt
@@ -13,7 +13,9 @@ import sopt.org.millie.presentation.bookdetail.model.BookSimilarModel
 import javax.inject.Inject
 
 @HiltViewModel
-class BookDetailViewModel @Inject constructor() : ViewModel() {
+class BookDetailViewModel
+    @Inject
+    constructor() : ViewModel() {
     private val _uiState = MutableStateFlow(BookDetailState())
     val uiState: StateFlow<BookDetailState> = _uiState.asStateFlow()
 
@@ -48,7 +50,6 @@ class BookDetailViewModel @Inject constructor() : ViewModel() {
                 bookTitle = "홍학의 자리",
                 bookAuthor = "정해연",
             ),
-
             )
 
         _uiState.update {
@@ -57,7 +58,7 @@ class BookDetailViewModel @Inject constructor() : ViewModel() {
     }
 
     fun onBackButtonClicked() {
-        //TODO: 네비 연결
+        // TODO: 네비 연결
     }
 
     fun onCompletedRateClicked() {

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/component/bar/BookDetailTopbar.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/component/bar/BookDetailTopbar.kt
@@ -1,7 +1,6 @@
 package sopt.org.millie.presentation.bookdetail.component.bar
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -19,6 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import sopt.org.millie.R
 import sopt.org.millie.core.designsystem.theme.MillieTheme
+import sopt.org.millie.core.util.noRippleClickable
 
 @Composable
 fun BookDetailTopbar(
@@ -39,7 +39,7 @@ fun BookDetailTopbar(
             tint = Color.Unspecified,
             modifier = Modifier
                 .size(24.dp)
-                .clickable(onClick = onBackButtonClick),
+                .noRippleClickable(onClick = onBackButtonClick),
         )
 
         Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/component/bar/BookDetailTopbar.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/component/bar/BookDetailTopbar.kt
@@ -1,9 +1,11 @@
 package sopt.org.millie.presentation.bookdetail.component.bar
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
@@ -21,19 +23,23 @@ import sopt.org.millie.core.designsystem.theme.MillieTheme
 @Composable
 fun BookDetailTopbar(
     bookDetailTopbarBackgroundColor: Color,
+    onBackButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .background(color = bookDetailTopbarBackgroundColor),
+            .background(color = bookDetailTopbarBackgroundColor)
+            .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
             imageVector = ImageVector.vectorResource(id = R.drawable.ic_detail_back),
             contentDescription = null,
             tint = Color.Unspecified,
-            modifier = Modifier.size(24.dp),
+            modifier = Modifier
+                .size(24.dp)
+                .clickable(onClick = onBackButtonClick),
         )
 
         Spacer(modifier = Modifier.weight(1f))
@@ -62,6 +68,7 @@ private fun Preview() {
     MillieTheme {
         BookDetailTopbar(
             bookDetailTopbarBackgroundColor = MillieTheme.colors.white,
+            onBackButtonClick = {},
         )
     }
 }

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/component/bar/ReadNowBar.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/component/bar/ReadNowBar.kt
@@ -1,6 +1,7 @@
 package sopt.org.millie.presentation.bookdetail.component.bar
 
 import androidx.annotation.DrawableRes
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -30,6 +31,7 @@ fun ReadNowBar(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .background(color = MillieTheme.colors.background)
             .padding(bottom = 10.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(10.dp),

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/component/book/BookDetailReview.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/component/book/BookDetailReview.kt
@@ -33,7 +33,7 @@ fun BookDetailReview(
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         UserInfo(
-            username = bookReview.username,
+            username = bookReview.reviewerName,
         )
 
         Text(
@@ -95,11 +95,13 @@ private fun Preview() {
     MillieTheme {
         BookDetailReview(
             bookReview = BookReviewModel(
-                username = "어진 님",
+                reviewerName = "어진 님",
+                bookId = 0,
                 reviewId = 1,
                 dateOfReview = "2023.06.06",
                 contentOfReview = "저는 책에 오타가 난 줄 알았어요",
                 likedNum = 10,
+                isLiked = false,
             ),
             onLikeClick = {},
         )

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/component/book/BookIntroduceSection.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/component/book/BookIntroduceSection.kt
@@ -16,7 +16,7 @@ import sopt.org.millie.core.util.noRippleClickable
 
 @Composable
 fun BookIntroduceSection(
-    reviewContent: String,
+    bookDescription: String,
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {},
 ) {
@@ -34,7 +34,7 @@ fun BookIntroduceSection(
         Spacer(modifier = Modifier.height(10.dp))
 
         Text(
-            text = reviewContent,
+            text = bookDescription,
             color = MillieTheme.colors.darkGray1,
             style = MillieTheme.typography.body.body1,
         )
@@ -57,7 +57,7 @@ fun BookIntroduceSection(
 private fun Preview() {
     MillieTheme {
         BookIntroduceSection(
-            reviewContent = "dfasdjfasdfasdfas",
+            bookDescription = "dfasdjfasdfasdfas",
             onClick = {},
         )
     }

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/component/book/BookReviewSection.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/component/book/BookReviewSection.kt
@@ -88,18 +88,22 @@ private fun Preview() {
             totalReviewCount = 100,
             bookReviews = persistentListOf(
                 BookReviewModel(
-                    username = "aaaa",
+                    reviewerName = "aaaa",
+                    bookId = 0,
                     reviewId = 1,
                     dateOfReview = "2023.01.01",
                     contentOfReview = "리뷰1",
                     likedNum = 100,
+                    isLiked = true
                 ),
                 BookReviewModel(
-                    username = "bbbb",
+                    reviewerName = "bbbb",
+                    bookId = 1,
                     reviewId = 2,
                     dateOfReview = "2023.01.01",
                     contentOfReview = "리뷰2",
                     likedNum = 100,
+                    isLiked = false
                 ),
             ),
             onReviewLikeClick = {},

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/component/book/BookReviewSection.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/component/book/BookReviewSection.kt
@@ -94,7 +94,7 @@ private fun Preview() {
                     dateOfReview = "2023.01.01",
                     contentOfReview = "리뷰1",
                     likedNum = 100,
-                    isLiked = true
+                    isLiked = true,
                 ),
                 BookReviewModel(
                     reviewerName = "bbbb",
@@ -103,7 +103,7 @@ private fun Preview() {
                     dateOfReview = "2023.01.01",
                     contentOfReview = "리뷰2",
                     likedNum = 100,
-                    isLiked = false
+                    isLiked = false,
                 ),
             ),
             onReviewLikeClick = {},

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/model/BookDetailModel.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/model/BookDetailModel.kt
@@ -6,15 +6,15 @@ import kotlinx.collections.immutable.persistentListOf
 
 @Immutable
 data class BookDetailModel(
-    val bookId: Long = 0,
-    val bookCoverImageUrl: String = "",
-    val bookTitle: String = "",
-    val bookAuthor: String = "",
-    val bookType: String = "",
-    val publishedDate: String = "",
-    val bookRate: Float = 0f,
-    val totalReviewCount: Int = 0,
-    val completionRate: Int = 0,
-    val bookDescription: String = "",
+    val bookId: Long,
+    val bookCoverImageUrl: String,
+    val bookTitle: String,
+    val bookAuthor: String,
+    val bookType: String,
+    val publishedDate: String,
+    val bookRate: Float,
+    val totalReviewCount: Int,
+    val completionRate: Int,
+    val bookDescription: String,
     val reviews: ImmutableList<BookReviewModel> = persistentListOf(),
 )

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/model/BookDetailModel.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/model/BookDetailModel.kt
@@ -1,0 +1,20 @@
+package sopt.org.millie.presentation.bookdetail.model
+
+import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+@Immutable
+data class BookDetailModel(
+    val bookId: Long = 0,
+    val bookCoverImageUrl: String = "",
+    val bookTitle: String = "",
+    val bookAuthor: String = "",
+    val bookType: String = "",
+    val publishedDate: String = "",
+    val bookRate: Float = 0f,
+    val totalReviewCount: Int = 0,
+    val completionRate: Int = 0,
+    val bookDescription: String = "",
+    val reviews: ImmutableList<BookReviewModel> = persistentListOf(),
+)

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/model/BookReviewModel.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/model/BookReviewModel.kt
@@ -4,9 +4,11 @@ import androidx.compose.runtime.Immutable
 
 @Immutable
 data class BookReviewModel(
-    val username: String,
     val reviewId: Long,
+    val bookId: Long,
+    val reviewerName: String,
     val dateOfReview: String,
     val contentOfReview: String,
     val likedNum: Int,
+    val isLiked: Boolean,
 )

--- a/app/src/main/java/sopt/org/millie/presentation/bookdetail/model/BookSimilarModel.kt
+++ b/app/src/main/java/sopt/org/millie/presentation/bookdetail/model/BookSimilarModel.kt
@@ -2,10 +2,11 @@ package sopt.org.millie.presentation.bookdetail.model
 
 import androidx.annotation.DrawableRes
 import androidx.compose.runtime.Immutable
+import sopt.org.millie.R
 
 @Immutable
 data class BookSimilarModel(
-    @DrawableRes val bookImage: Int,
-    val bookTitle: String,
-    val bookAuthor: String,
+    @DrawableRes val bookImage: Int = R.drawable.img_detail_book1,
+    val bookTitle: String = "",
+    val bookAuthor: String = "",
 )


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- 리뷰는 PR이 올라오면 최대한 빠르게 진행합니다.
- P1 단계의 리뷰는 빠르게 확인 후 반영합니다.
- Approve된 PR은 assigner가 머지하고,
  수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #31

## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 도서 상세 페이지 구현 했습니다.

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
<img width="200" height="400" alt="스크린샷 2025-11-24 오후 9 09 56" src="https://github.com/user-attachments/assets/358dfb8b-ef81-4b14-9b64-a393f45b4ae1" />
<img width="200" height="400" alt="스크린샷 2025-11-24 오후 9 10 01" src="https://github.com/user-attachments/assets/4d9dc092-136d-47f9-bda4-f374be1c7b24" />


## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
화면상 비어있는 부분은 서버에서 받아오는 데이터 또는 더미 데이터 부분입니다!
뷰모델에 더미 데이터를 만들어놨는데 프리뷰에 더미 데이터를 또 넣기 귀찮아서 안 했는데 혹시 더미 데이터 넣은것까지 확인하기 원하시면 말씀해주세요!! 그럼 추가해놓겠습니다:)
